### PR TITLE
Add style customization to prompt generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project is a backend service built with **FastAPI** to generate UI images f
 ## ✅ What This Backend Does
 
 - Accepts a text-based requirement via an HTTP POST request.
+- Optional parameters allow specifying typography and a color palette for the generated UI.
 - Generates a UI image using OpenAI's API.
 - Returns a URL to the generated image saved under `src/confluence_plugin_be/images/`.
 - Provides a `/docs` page for testing via Swagger UI.
@@ -46,6 +47,15 @@ services/ui_generator.py           → Calls OpenAI to create an image and save 
 config.py                          → Loads the OpenAI API key from .env
 images/                            → Stores the generated image files
 
+```
+
+Example Request
+```json
+{
+  "requirement": "Pantalla de inicio para aplicación de seguimiento de gastos.",
+  "typography": "Roboto, 14px",
+  "palette": "#0070f3 (azul principal), #ff4081 (botones), #f0f0f0 (fondo)"
+}
 ```
 
 Example Response

--- a/src/confluence_plugin_be/api/routes.py
+++ b/src/confluence_plugin_be/api/routes.py
@@ -5,10 +5,20 @@ from src.confluence_plugin_be.services.ui_generator import generate_ui_image
 
 router = APIRouter()
 
-@router.post("/generate-ui", response_model=UIResponse, tags=["UI Generation"], summary="Generate a UI image from a requirement")
+
+@router.post(
+    "/generate-ui",
+    response_model=UIResponse,
+    tags=["UI Generation"],
+    summary="Generate a UI image from a requirement",
+)
 async def generate_ui(req: UIRequest):
     try:
-        image_url = generate_ui_image(req.requirement)
+        image_url = generate_ui_image(
+            req.requirement,
+            typography=req.typography,
+            palette=req.palette,
+        )
         return {"status": "success", "image_url": image_url}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/confluence_plugin_be/main.py
+++ b/src/confluence_plugin_be/main.py
@@ -4,10 +4,13 @@ from .api.routes import router
 
 app = FastAPI(title="Confluence Plugin Backend")
 
+
 @app.get("/")
 def root():
     return {"message": "FastAPI backend is up"}
 
-app.include_router(router)
-app.mount("/images", StaticFiles(directory="src/confluence_plugin_be/images"), name="images")
 
+app.include_router(router)
+app.mount(
+    "/images", StaticFiles(directory="src/confluence_plugin_be/images"), name="images"
+)

--- a/src/confluence_plugin_be/models/requests/ui_request_model.py
+++ b/src/confluence_plugin_be/models/requests/ui_request_model.py
@@ -1,4 +1,8 @@
+from typing import Optional
 from pydantic import BaseModel
+
 
 class UIRequest(BaseModel):
     requirement: str
+    typography: Optional[str] = None
+    palette: Optional[str] = None

--- a/src/confluence_plugin_be/models/responses/ui_response_model.py
+++ b/src/confluence_plugin_be/models/responses/ui_response_model.py
@@ -1,6 +1,7 @@
 # models/response_models.py
 from pydantic import BaseModel
 
+
 class UIResponse(BaseModel):
     status: str
     image_url: str

--- a/src/confluence_plugin_be/services/ui_generator.py
+++ b/src/confluence_plugin_be/services/ui_generator.py
@@ -8,27 +8,35 @@ from src.confluence_plugin_be.config import OPENAI_API_KEY
 IMG_DIR = Path(__file__).resolve().parent.parent / "images"
 
 
-def generate_ui_image(requirement: str) -> str:
-    prompt = process_requirement(requirement)
+def generate_ui_image(
+    requirement: str, typography: str | None = None, palette: str | None = None
+) -> str:
+    """Generate a UI image given a requirement and optional style hints."""
+    prompt = process_requirement(requirement, typography=typography, palette=palette)
     image_b64 = request_image(prompt)
     filename = save_image(image_b64)
     return f"/images/{filename}"
 
-def process_requirement(requirement: str) -> str:
-    # TO DO:    Need to change this, create some prompt engeneering or something xd
-    #           I was thinking of something like the folder structure of Diore and Sofi previous project
-    #           where they had multiple prompt templates, so maybe we could select them by parameters and 
-    #           enhance them with the requirement input to make them more specific.
-    prompt_with_requirement = """You are a minimalistic mobile UX/UI designer. 
-                                Now you are working a new feature based 
-                                on the following requirement: """ + requirement + """
-                                Create a UI image for this requirement.
-                                The image should be minimalistic,
-                                modern and easy to use.
-                                The image should be the size of a mobile screen.
-                                The background is always white.
-                                """
-    return prompt_with_requirement
+
+def process_requirement(
+    requirement: str, *, typography: str | None = None, palette: str | None = None
+) -> str:
+    """Build the prompt text for the image generation request."""
+    prompt_lines = [
+        "You are a mobile UX/UI designer.",
+        f"Requirement: {requirement}",
+    ]
+    if typography:
+        prompt_lines.append(f"Typography: {typography}")
+    if palette:
+        prompt_lines.append(f"Color palette: {palette}")
+
+    prompt_lines.append(
+        "Create a UI mockup that follows these guidelines and is suitable for a Confluence page."
+    )
+
+    return "\n".join(prompt_lines)
+
 
 def request_image(prompt: str) -> str:
     response = openai.images.generate(
@@ -39,6 +47,7 @@ def request_image(prompt: str) -> str:
         response_format="b64_json",
     )
     return response.data[0].b64_json
+
 
 def save_image(b64_image: str) -> str:
     image_data = base64.b64decode(b64_image)


### PR DESCRIPTION
## Summary
- pass typography and palette via API to generate customized prompts
- document request parameters in README
- format codebase with black

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*